### PR TITLE
set deploy strategy to rolling

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,3 +3,6 @@ primary_region = "cdg"
 
 [env]
   SENTRY_ENVIRONMENT = "production"
+
+[deploy]
+  strategy = "rolling"


### PR DESCRIPTION
To ensure only one instance is running at a time